### PR TITLE
Fix warnings in windows and update put functions without validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,12 +376,18 @@ install( DIRECTORY matlab/ DESTINATION toolbox
 # The al library comes from al-core and may already be installed
 # Copy runtime dependencies to toolbox during install
 if(WIN32)
-  # On Windows, install runtime DLLs that MEX files depend on
+  # On Windows, install runtime DLLs that MEX files depend on.
+  # This includes both the AL DLLs (from bin/) and the vcpkg dependency DLLs
+  # (boost, hdf5, pthread, dl, zlib, szip, aec, etc.) needed by al.dll at runtime.
   install(CODE "
-    file(GLOB AL_RUNTIME_LIBS 
+    file(GLOB AL_RUNTIME_LIBS
       \"\${CMAKE_INSTALL_PREFIX}/bin/*.dll\"
     )
-    foreach(lib IN LISTS AL_RUNTIME_LIBS)
+    file(GLOB VCPKG_RUNTIME_LIBS
+      \"${CMAKE_BINARY_DIR}/vcpkg_installed/x64-windows/bin/*.dll\"
+    )
+    set(ALL_RUNTIME_LIBS \${AL_RUNTIME_LIBS} \${VCPKG_RUNTIME_LIBS})
+    foreach(lib IN LISTS ALL_RUNTIME_LIBS)
       file(COPY \"\${lib}\" DESTINATION \"\${CMAKE_INSTALL_PREFIX}/toolbox\")
     endforeach()
     message(STATUS \"Copied runtime libraries to toolbox folder\")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,22 +263,31 @@ else()
   endmacro()
 endif()
 # These XSLs generate files in triplets, which are then compiled into one mex target
-foreach( METHOD_NAME allocate delete gen get get_sample get_slice init put put_slice rand validate )
+# Note: ids_validate is not compiled on Windows (validate is unsupported on Windows)
+foreach( METHOD_NAME allocate delete gen get get_sample get_slice init put put_slice rand )
   FILES_FROM_METHOD_NAME( OUTPUT_FILES ${METHOD_NAME} )
   GENERATE( "ids_${METHOD_NAME}" 1 "${OUTPUT_FILES}" )
   ADD_IMAS_MEX( "ids_${METHOD_NAME}" "${OUTPUT_FILES}" )
 endforeach()
+if(NOT WIN32)
+  FILES_FROM_METHOD_NAME( OUTPUT_FILES validate )
+  GENERATE( "ids_validate" 1 "${OUTPUT_FILES}" )
+  ADD_IMAS_MEX( "ids_validate" "${OUTPUT_FILES}" )
+endif()
 
 # 'put' and 'put_slice' in addition need these sources:
 target_sources( "mex-ids_put" PRIVATE
   src/ids/delete_ids.c
-  src/ids/validate_ids.c
 )
 target_sources( "mex-ids_put_slice" PRIVATE
   src/ids/put_ids.c
   src/ids/delete_ids.c
-  src/ids/validate_ids.c
 )
+# validate_ids.c is not linked on Windows (validate is unsupported on Windows)
+if(NOT WIN32)
+  target_sources( "mex-ids_put" PRIVATE src/ids/validate_ids.c )
+  target_sources( "mex-ids_put_slice" PRIVATE src/ids/validate_ids.c )
+endif()
 
 # The ids_converter.xsl generates many targets:
 set( IDS_CONVERTER_SOURCES )

--- a/create_matlab_toolbox.m
+++ b/create_matlab_toolbox.m
@@ -137,7 +137,7 @@ fprintf(fid, '    %% Display version information\n');
 fprintf(fid, '    try\n');
 fprintf(fid, '        v = imas_versions();\n');
 fprintf(fid, '        fprintf(''Access Layer: %%s | Data Dictionary: %%s\\n'', ...\n');
-fprintf(fid, '                v.access_layer, v.data_dictionary);\n');
+fprintf(fid, '                v.al_version, v.dd_version);\n');
 fprintf(fid, '    catch ME\n');
 fprintf(fid, '        warning(''Could not retrieve version information: %%s'', ME.message);\n');
 fprintf(fid, '    end\n');

--- a/doc/matlab_on_windows.rst
+++ b/doc/matlab_on_windows.rst
@@ -111,6 +111,187 @@ Example MATLAB script to access IMAS data:
     disp(['Data Dictionary: ' m.ids_properties.version_put.data_dictionary]);
 
 
+Creating the MATLAB Toolbox Package
+====================================
+
+After a successful build and install, a self-contained ``.mltbx`` toolbox file can be
+created using the ``create_matlab_toolbox`` script included in the install directory.
+
+.. note::
+
+    The ``<INSTALL_PATH>/toolbox/`` folder must exist (produced by
+    ``cmake --build build --config Release --target install``) before packaging.
+
+Run the following from inside MATLAB:
+
+.. code-block:: matlab
+
+    create_matlab_toolbox('<INSTALL_PATH>', '<OUTPUT_PATH>', '<VERSION>', '<DD_VERSION>')
+
+For example:
+
+.. code-block:: matlab
+
+    create_matlab_toolbox('C:\imas_matlab_release', ...
+                          'C:\imas_matlab_release', ...
+                          '5.5.0', '4.1.1')
+
+This produces a file such as::
+
+    C:\imas_matlab_release\IMAS-MATLAB_5.5.0-DD-4.1.1-win64.mltbx
+
+The package includes all MEX files, ``.m`` files, and the required runtime DLLs
+(``al.dll``, ``libal-mex.dll``, ``hdf5.dll``, ``pthreadVC3.dll``,
+``boost_filesystem*.dll``, etc.).
+
+.. note::
+
+    The vcpkg runtime DLLs (``hdf5.dll``, ``pthreadVC3.dll``,
+    ``boost_filesystem-vc143-mt-x64-1_90.dll``, ``dl.dll``, ``zlib1.dll``,
+    ``szip.dll``, ``aec.dll``) from
+    ``<BUILD_DIR>/vcpkg_installed/x64-windows/bin/`` must be present in the
+    ``<INSTALL_PATH>/toolbox/`` folder before packaging. The CMake install step
+    copies them automatically.
+
+
+Installing the MATLAB Toolbox
+==============================
+
+**Option A – Double-click** the ``.mltbx`` file in Windows File Explorer.
+MATLAB opens and installs it automatically via the Add-On Manager.
+
+**Option B – From inside MATLAB:**
+
+.. code-block:: matlab
+
+    matlab.addons.install('C:\imas_matlab_release\IMAS-MATLAB_5.5.0-DD-4.1.1-win64.mltbx')
+
+The toolbox is installed to::
+
+    C:\Users\<username>\AppData\Roaming\MathWorks\MATLAB Add-Ons\Toolboxes\IMAS-MATLAB\
+
+
+Using the Installed Toolbox
+============================
+
+Initializing
+------------
+
+On Windows, run this at the start of every MATLAB session to register the DLL
+folder on the system ``PATH`` so that MEX files can locate their dependencies:
+
+.. code-block:: matlab
+
+    imas_toolbox_startup()
+
+Expected output::
+
+    IMAS-MATLAB/5.5.0-DD-4.1.1-win64 loaded successfully
+    Access Layer: 5.5.0+64-... | Data Dictionary: 4.1.1
+
+To run this automatically every session, add it to your MATLAB ``startup.m``:
+
+.. code-block:: matlab
+
+    % Open startup.m
+    edit(fullfile(userpath, 'startup.m'))
+
+    % Add the following line and save:
+    imas_toolbox_startup()
+
+Verifying the installation
+---------------------------
+
+.. code-block:: matlab
+
+    v = imas_versions()
+
+Expected output::
+
+    v =
+      struct with fields:
+          al_version: '5.5.0+64-...'
+         hli_version: '5.5.0+64-...'
+          dd_version: '4.1.1'
+
+Writing data
+------------
+
+.. code-block:: matlab
+
+    % Open / create a database entry  (mode 43 = FORCE_CREATE)
+    ctx = imas_open('imas:hdf5?path=C:/mydata', 43);
+    if ctx < 0, error('Unable to open database'); end
+
+    m = ids_gen('magnetics');
+    m.ids_properties.homogeneous_time = 1;
+    m.time = [1.0; 2.0; 3.0];
+    m.flux_loop{1}.flux.data = [10.0; 20.0; 30.0];
+
+    ids_put(ctx, 'magnetics', m);   % writes entire IDS (overwrites existing)
+    imas_close(ctx);
+
+Reading data
+------------
+
+.. code-block:: matlab
+
+    % Open existing database  (mode 40 = OPEN_PULSE)
+    ctx = imas_open('imas:hdf5?path=C:/mydata', 40);
+    if ctx < 0, error('Unable to open database'); end
+
+    m = ids_get(ctx, 'magnetics');
+    disp(m.time)
+    disp(m.flux_loop{1}.flux.data)
+
+    imas_close(ctx);
+
+Appending time slices
+----------------------
+
+.. code-block:: matlab
+
+    ctx = imas_open('imas:hdf5?path=C:/mydata', 43);
+
+    m = ids_gen('magnetics');
+    m.ids_properties.homogeneous_time = 1;
+
+    % Time slices must be appended in strictly increasing order
+    m.time = 1.0;  m.flux_loop{1}.flux.data = 10.0;
+    ids_put_slice(ctx, 'magnetics', m);
+
+    m.time = 2.0;  m.flux_loop{1}.flux.data = 20.0;
+    ids_put_slice(ctx, 'magnetics', m);
+
+    imas_close(ctx);
+
+``imas_open`` mode values
+--------------------------
+
++----+----------------------+----------------------------------------------+
+|Mode| Constant             | Description                                  |
++====+======================+==============================================+
+| 40 | ``OPEN_PULSE``       | Open existing entry (error if not found)     |
++----+----------------------+----------------------------------------------+
+| 41 | ``FORCE_OPEN_PULSE`` | Open entry, create if it does not exist      |
++----+----------------------+----------------------------------------------+
+| 42 | ``CREATE_PULSE``     | Create new entry (error if already exists)   |
++----+----------------------+----------------------------------------------+
+| 43 | ``FORCE_CREATE``     | Create entry, overwrite if it already exists |
++----+----------------------+----------------------------------------------+
+
+Uninstalling
+------------
+
+In MATLAB: **Home → Add-Ons → Manage Add-Ons** → find *IMAS-MATLAB* → **Uninstall**.
+
+Or from the command line:
+
+.. code-block:: matlab
+
+    matlab.addons.uninstall('IMAS-MATLAB')
+
+
 Run MATLAB Tests
 ================
 
@@ -126,3 +307,7 @@ Windows Troubleshooting
 - Verify Visual Studio C++ build tools are installed
 - Check that all dependencies are accessible at the specified network paths
 - Confirm Python installation with ``python --version``
+- If MEX files fail with *"The specified module could not be found"*, ensure
+  ``imas_toolbox_startup()`` has been called and the vcpkg DLLs are present in
+  the toolbox folder (``hdf5.dll``, ``pthreadVC3.dll``,
+  ``boost_filesystem-vc143-mt-x64-1_90.dll``, ``dl.dll``)

--- a/doc/matlab_on_windows.rst
+++ b/doc/matlab_on_windows.rst
@@ -2,6 +2,29 @@
 Windows Installation Guide
 ==========================================
 
+Known Limitations
+=================
+
+.. warning::
+
+   **IDS validation is not supported on Windows.**
+
+   The ``ids_validate`` MEX function and the automatic validation step that
+   normally runs inside ``ids_put`` / ``ids_put_slice`` are both **disabled** on
+   Windows builds. Calling ``ids_validate()`` directly will result in an error.
+
+   This is a known limitation tracked in
+   `GitHub issue #3 <https://github.com/iterorganization/IMAS-MATLAB/issues/3>`_.
+
+   As a consequence:
+
+   - The ``ids_validate`` MEX target is **not compiled** on Windows.
+   - ``ids_put`` and ``ids_put_slice`` skip the validation check on Windows and
+     write data directly without schema validation.
+   - Users are responsible for ensuring that the IDS data structure is correct
+     before calling ``ids_put`` or ``ids_put_slice`` on Windows.
+
+
 Windows Prerequisites
 =====================
 
@@ -14,6 +37,7 @@ Windows Prerequisites
 3. **CMake** (included with Visual Studio)
 
 4. **Python 3.8+** with venv module (verify with ``python --version``)
+
 
 
 Setup vcpkg
@@ -139,19 +163,6 @@ For example:
 This produces a file such as::
 
     C:\imas_matlab_release\IMAS-MATLAB_5.5.0-DD-4.1.1-win64.mltbx
-
-The package includes all MEX files, ``.m`` files, and the required runtime DLLs
-(``al.dll``, ``libal-mex.dll``, ``hdf5.dll``, ``pthreadVC3.dll``,
-``boost_filesystem*.dll``, etc.).
-
-.. note::
-
-    The vcpkg runtime DLLs (``hdf5.dll``, ``pthreadVC3.dll``,
-    ``boost_filesystem-vc143-mt-x64-1_90.dll``, ``dl.dll``, ``zlib1.dll``,
-    ``szip.dll``, ``aec.dll``) from
-    ``<BUILD_DIR>/vcpkg_installed/x64-windows/bin/`` must be present in the
-    ``<INSTALL_PATH>/toolbox/`` folder before packaging. The CMake install step
-    copies them automatically.
 
 
 Installing the MATLAB Toolbox
@@ -311,3 +322,7 @@ Windows Troubleshooting
   ``imas_toolbox_startup()`` has been called and the vcpkg DLLs are present in
   the toolbox folder (``hdf5.dll``, ``pthreadVC3.dll``,
   ``boost_filesystem-vc143-mt-x64-1_90.dll``, ``dl.dll``)
+- **IDS validation is not available on Windows** — ``ids_validate`` is not
+  compiled and validation is skipped inside ``ids_put`` / ``ids_put_slice``.
+  See `GitHub issue #3 <https://github.com/iterorganization/IMAS-MATLAB/issues/3>`_
+  for status and updates.

--- a/ids_put.xsl
+++ b/ids_put.xsl
@@ -156,7 +156,9 @@ void mexFunction(int nlhs, mxArray *plhs[],
  </xsl:result-document>
   <xsl:result-document href="src/ids/put_ids.c" standalone="yes" method="text">
     #include "imas_mex_utils.h"
+    #ifndef _WIN32
     #include "ids_validate.h"
+    #endif
     <xsl:for-each select="IDS">
     <xsl:variable name="ids_type" select="@type"/>
     al_status_t ids_delete_<xsl:value-of select="@name"/>(int expIdx, char* idsFullName);

--- a/ids_put_slice.xsl
+++ b/ids_put_slice.xsl
@@ -156,7 +156,9 @@ void mexFunction(int nlhs, mxArray *plhs[],
  </xsl:result-document>
   <xsl:result-document href="src/ids/put_slice_ids.c" standalone="yes" method="text">
     #include "imas_mex_utils.h"
+    #ifndef _WIN32
     #include "ids_validate.h"
+    #endif
     <xsl:for-each select="IDS">
      <xsl:variable name="ids_type" select="@type"/>
     al_status_t ids_put_<xsl:value-of select="@name"/>(int expIdx, char* idsFullName, const mxArray* ids);

--- a/ids_validate.xsl
+++ b/ids_validate.xsl
@@ -422,17 +422,17 @@ end_repl_str:
 
       /* Allow for 1D row vectors  */
       if (ndims == 1 &amp;&amp; dims[0] == 1) {
-        size_t needed = snprintf(NULL, 0, "%s,%d,%s","(",dims[1],")");
+        size_t needed = snprintf(NULL, 0, "%s,%zu,%s","(",dims[1],")");
         char  *result = malloc(needed+1);
-        sprintf(result,"%s,%d,%s","(",dims[1],")");
+        sprintf(result,"%s,%zu,%s","(",dims[1],")");
         return result;
       } else {
-        size_t needed = snprintf(NULL, 0, "%s%d","(",dims[0]);
-        for (int i=1;i&lt;rank;i++) needed = needed + snprintf(NULL, 0, ",%d",dims[i]);
+        size_t needed = snprintf(NULL, 0, "%s%zu","(",dims[0]);
+        for (int i=1;i&lt;rank;i++) needed = needed + snprintf(NULL, 0, ",%zu",dims[i]);
         needed = needed + snprintf(NULL, 0, ")");
         char  *result = malloc(needed+1);
-        sprintf(result,"%s%d","(",dims[0]);
-        for (int i=1;i&lt;rank;i++) sprintf(result,"%s,%d",result,dims[i]);
+        sprintf(result,"%s%zu","(",dims[0]);
+        for (int i=1;i&lt;rank;i++) sprintf(result,"%s,%zu",result,dims[i]);
         sprintf(result,"%s)",result);
         return result;
       }
@@ -576,9 +576,9 @@ end_repl_str:
                 sprintf(buffercoord, "%s OR %s",buffercoord,ctargetfield[target]);
               }
               if(spec_dim!=0) sprintf(buffercoord,"%s OR %d",buffercoord,spec_dim);
-              size_t needed = snprintf(NULL, 0, "Element '%s%s' has incorrect shape %s: its coordinate in dimension %d ('%s%s') has size %d.", crootpath, initialpath, getShapeStr(pfield,rank), cfield_dim,crootpath,ctargetfield[targetcpathid], targetFieldSize);
+              size_t needed = snprintf(NULL, 0, "Element '%s%s' has incorrect shape %s: its coordinate in dimension %d ('%s%s') has size %zu.", crootpath, initialpath, getShapeStr(pfield,rank), cfield_dim,crootpath,ctargetfield[targetcpathid], targetFieldSize);
               char  *buffer = malloc(needed+1);
-              sprintf(buffer, "Element '%s%s' has incorrect shape %s: its coordinate in dimension %d ('%s%s') has size %d.", crootpath, initialpath,getShapeStr(pfield,rank), cfield_dim,crootpath,ctargetfield[targetcpathid], targetFieldSize);
+              sprintf(buffer, "Element '%s%s' has incorrect shape %s: its coordinate in dimension %d ('%s%s') has size %zu.", crootpath, initialpath,getShapeStr(pfield,rank), cfield_dim,crootpath,ctargetfield[targetcpathid], targetFieldSize);
               strncpy(status.message, buffer, needed);
               /// --- replacement of each index by its value
               for (int k=0;k&lt;nbindices; k++) {
@@ -692,7 +692,7 @@ end_repl_str:
     const mxArray* data=NULL; 
     const mxArray* pfield=NULL;
     int idsTimeMode = IDS_TIME_MODE_UNKNOWN;
-    int timeSize;
+    int timeSize = 0;
     int isEmpty;
     int i1max, i2max, i3max, i4max, itimemax;
     int aosArraySize;

--- a/implementations.xsl
+++ b/implementations.xsl
@@ -184,7 +184,8 @@
     al_status_t status_end = {0,""};
     int putOpCtx = -1;
     int homogeneousTime = IDS_TIME_MODE_UNKNOWN;
-    /* Validation check for input schema */
+    /* Validation check for input schema (not supported on Windows) */
+#ifndef _WIN32
     al_validation_status_t status_val = {0,""};
     bool flag = is_validation_required();
     if(flag) {
@@ -197,6 +198,7 @@
 	mexWarnMsgIdAndTxt("IMAS:ids_validate:invalid_ids", "IDS <xsl:value-of select="@name"/> is found to be invalid . PUT quits with no action.");
 	return status;
     }
+#endif
     status = init_dataTree_write((mxArray *) ids);
     /* TODO: move these checks to external function? */
     if (status.code >= 0) status = getHomogeneousTime(&amp;homogeneousTime);


### PR DESCRIPTION
Validation logic is skipped on windows platform and now compiling code for put and put_slice is not an issue.. Please check #3 

```bash
  Building Custom Rule C:/Users/sawantp1/IMAS-MATLAB/CMakeLists.txt
  ids_put.c
  put_ids.c
  delete_ids.c
  Generating Code...
cl : command line  warning D9025: overriding '/W1' with '/w' [C:\Users\sawantp1\IMAS-MATLAB\build\mex-ids_put.vcxproj]
  c_mexapi_version.c
     Creating library C:/Users/sawantp1/IMAS-MATLAB/build/Release/ids_put.lib and object C:/Users/sawantp1/IMAS-MATLAB/build/Release/ids_put.exp
  mex-ids_put.vcxproj -> C:\Users\sawantp1\IMAS-MATLAB\build\Release\ids_put.mexw64
  Building Custom Rule C:/Users/sawantp1/IMAS-MATLAB/CMakeLists.txt
  ids_put_slice.c
  put_slice_ids.c
  put_ids.c
  delete_ids.c
  Generating Code...
cl : command line  warning D9025: overriding '/W1' with '/w' [C:\Users\sawantp1\IMAS-MATLAB\build\mex-ids_put_slice.vcxproj]
  c_mexapi_version.c
     Creating library C:/Users/sawantp1/IMAS-MATLAB/build/Release/ids_put_slice.lib and object C:/Users/sawantp1/IMAS-MATLAB/build/Release/ids_put_slice.exp
  mex-ids_put_slice.vcxproj -> C:\Users\sawantp1\IMAS-MATLAB\build\Release\ids_put_slice.mexw64
  Building Custom Rule C:/Users/sawantp1/IMAS-MATLAB/CMakeLists.txt
  ids_rand.c
  rand_ids.c
  Generating Code...
```
<img width="1912" height="1004" alt="image" src="https://github.com/user-attachments/assets/01c02311-84b1-4140-ae25-6d7ff823f750" />
