### PR TITLE
skip the write of CHAR_DATA when it is empty

### DIFF
--- a/src/imas_mex_casts.c
+++ b/src/imas_mex_casts.c
@@ -274,6 +274,11 @@ al_status_t castCellToChar(mxArray ** data)
 
   numel = mxGetNumberOfElements(cellData);
 
+  if (numel == 0) {
+    *data = NULL;
+    return status;
+  }
+
   strings = malloc(numel*sizeof(char *));
   for (i = 0; i < numel; i++) {
     cell = mxGetCell(*data, (mwIndex) i);

--- a/src/imas_mex_utils.c
+++ b/src/imas_mex_utils.c
@@ -975,6 +975,7 @@ al_status_t my_al_write_data(struct imas_mex_actionInfo * action, struct imas_me
 	if (field->datatype == CHAR_DATA && field->dim == 2) {
 		if (mxIsCell(data)) {
 			if (status.code >= 0) status = cast_status = castCellToChar((mxArray **) &data);
+			if (data == NULL) return (al_status_t) {0,""};
 		}
 	}
 


### PR DESCRIPTION
``` bash
user = getenv('USER');
%tmp1=shot
%tmp2=run

backend="hdf5";
shot=1050
run=1
machine='test'
if backend=='mdsplus'
    idx = imas_create_env ('ids',shot,run,0,0,user, convertStringsToChars(machine),'3')   % for MDS+ backend
elseif backend=='hdf5'
    idx = imas_create_env_backend (shot,run,user,convertStringsToChars(machine),'3',13); % for HDF5 backend
else
    display('no valid backend given, return')
end

hom_time_value=1
clear core_profiles
cp = ids_init('core_profiles')
cp.ids_properties.comment = 'test';
cp.ids_properties.homogeneous_time = hom_time_value;

cp.time=1.0

%working
%nt=1;

%not working
nt=7736;

%cp.profiles_1d=ids_allocate('core_profiles','profiles_1d',nt);
cp.profiles_1d=ids_allocate('core_profiles','profiles_1d',nt);

% Fill cp.time 
cp.time = linspace(0.1, 773.6, nt);

tmp31=cp

ids_put(idx,'core_profiles',cp);

disp ('Closing database')
imas_close(idx);
```

<img width="1627" height="742" alt="image" src="https://github.com/user-attachments/assets/487fcc59-4f82-42ea-be09-abe1e4841879" />
